### PR TITLE
Enable user and listing deletion

### DIFF
--- a/src/main/java/com/example/gilbertextra/application/ListingService.java
+++ b/src/main/java/com/example/gilbertextra/application/ListingService.java
@@ -158,4 +158,12 @@ public class ListingService {
         return listingRepository.findByUserIdAndStatus(userId, Listing.Status.SOLD);
     }
 
+    public void deleteListing(Long listingId, Long userId) {
+        Listing listing = listingRepository.findListingById(listingId);
+        if (listing == null || !listing.getSellerId().equals(userId)) {
+            throw new SecurityException("User not allowed to delete this listing");
+        }
+        listingRepository.deleteById(listingId);
+    }
+
 }

--- a/src/main/java/com/example/gilbertextra/application/UserService.java
+++ b/src/main/java/com/example/gilbertextra/application/UserService.java
@@ -70,4 +70,8 @@ public class UserService {
     public User getPublicUserById(long userId) {
         return userRepository.findUserById(userId);
     }
+
+    public void deleteUser(long userId) {
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/com/example/gilbertextra/infrastructure/ListingRepository.java
+++ b/src/main/java/com/example/gilbertextra/infrastructure/ListingRepository.java
@@ -250,4 +250,9 @@ public class ListingRepository {
             return listing;
         });
     }
+
+    public void deleteById(Long listingId) {
+        String sql = "DELETE FROM listings WHERE listing_id = ?";
+        jdbcTemplate.update(sql, listingId);
+    }
 }

--- a/src/main/java/com/example/gilbertextra/presentation/MainController.java
+++ b/src/main/java/com/example/gilbertextra/presentation/MainController.java
@@ -274,6 +274,16 @@ public class MainController {
         return "redirect:/privateUser";
 
     }
+
+    @PostMapping("/deleteUser")
+    public String deleteUser(HttpSession session) {
+        User currentUser = (User) session.getAttribute("currentUser");
+        if (currentUser != null) {
+            userService.deleteUser(currentUser.getUserId());
+            session.invalidate();
+        }
+        return "redirect:/home";
+    }
     //side til opret listing
     @GetMapping("/createSale")
     public String showCreateListingForm(Model model, HttpSession session) {
@@ -348,6 +358,16 @@ public class MainController {
         Listing listing = listingService.getListingById(id);
         model.addAttribute("listing", listing);
         return "listingPage";
+    }
+
+    @PostMapping("/listings/{id}/delete")
+    public String deleteListing(@PathVariable Long id, HttpSession session) {
+        User currentUser = (User) session.getAttribute("currentUser");
+        if (currentUser == null) {
+            return "redirect:/login";
+        }
+        listingService.deleteListing(id, currentUser.getUserId());
+        return "redirect:/privateUser";
     }
 
     //side til admins

--- a/src/main/resources/templates/editUser.html
+++ b/src/main/resources/templates/editUser.html
@@ -51,7 +51,7 @@
 
         <p class="d-inline-flex gap-5 buttons mx-2 mb-3">
             <button type="submit" class="btn btn-success">Edit profile</button>
-            <button class="btn btn-danger">Delete profile</button>
+            <button type="submit" formaction="/deleteUser" class="btn btn-danger">Delete profile</button>
         </p>
 
     </div>

--- a/src/main/resources/templates/privateUser.html
+++ b/src/main/resources/templates/privateUser.html
@@ -78,6 +78,9 @@
             <div class="mt-auto">
               <a th:href="@{/listings/{id}(id=${listing.listingId})}"
                  class="btn btn-outline-success w-100 mb-1">View details</a>
+              <form th:action="@{/listings/{id}/delete(id=${listing.listingId})}" method="post">
+                <button type="submit" class="btn btn-danger w-100">Delete</button>
+              </form>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add deleteById to `ListingRepository`
- allow users to remove their listings via `ListingService`
- add account deletion in `UserService`
- expose new delete endpoints in `MainController`
- wire up delete buttons in `editUser.html` and `privateUser.html`

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6842bcbc58bc8332a727eacc7cf693be